### PR TITLE
Improve offline mode

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -13,7 +13,8 @@
     "m15_for_analysis": 50,
     "m1_for_analysis": 50,
     "m15_for_chart": 100,
-    "m1_for_chart": 100
+    "m1_for_chart": 100,
+    "skip_on_no_trade": { "m1": 90, "m15": 6 }
   },
   "trade_rules": {
     "order_expiry_minutes": 45,

--- a/index.js
+++ b/index.js
@@ -4,17 +4,56 @@
  */
 
 const { connectToWhatsApp } = require('./src/bot/bot.js');
+const { runBacktest } = require('./src/engine/main');
 const logger = require('./src/utils/logger');
 
-function main() {
+function parseCliArgs(args) {
+  const cfg = {};
+  args.forEach(arg => {
+    const [key, value] = arg.split('=');
+    if (key && value) {
+      cfg[key.replace(/^--?/, '')] = value;
+    }
+  });
+  return cfg;
+}
+
+async function runCliMode(cliCfg) {
+  const required = ['pair', 'prompt', 'start', 'end'];
+  const missing = required.filter(k => !cliCfg[k]);
+  if (missing.length) {
+    logger.error(`[CLI] Argumen tidak lengkap: ${missing.join(', ')}`);
+    return;
+  }
+  const backtestCfg = {
+    pair: cliCfg.pair,
+    promptFile: cliCfg.prompt,
+    startDate: cliCfg.start,
+    endDate: cliCfg.end,
+    notificationMode: parseInt(cliCfg.notify || '0', 10),
+  };
+  logger.warn('[CLI] Menjalankan backtest tanpa WhatsApp.');
+  await runBacktest(backtestCfg, null, null);
+}
+
+async function main() {
+  const cliCfg = parseCliArgs(process.argv.slice(2));
+
   logger.info('====================================');
   logger.info('   Memulai Aplikasi Backtester Bot  ');
   logger.info('====================================');
-  
-  connectToWhatsApp().catch(err => {
+
+  if (cliCfg.offline === '1' || cliCfg.offline === 'true') {
+    await runCliMode(cliCfg);
+    return;
+  }
+
+  try {
+    await connectToWhatsApp();
+  } catch (err) {
     logger.error('[APP] Gagal memulai koneksi WhatsApp:', err);
-    process.exit(1); // Keluar dari aplikasi jika koneksi awal gagal
-  });
+    await runCliMode(cliCfg);
+  }
 }
 
 // Jalankan fungsi utama


### PR DESCRIPTION
## Summary
- add CLI fallback so the backtester can run without WhatsApp
- parse simple CLI args and run backtest offline when requested
- keep NO_TRADE skip settings in config

## Testing
- `npm install`
- `node index.js offline=1 pair=EURUSD prompt=gbpusd.txt start=2025-07-01 end=2025-07-02` *(fails to fetch OHLCV data)*

------
https://chatgpt.com/codex/tasks/task_b_686db5b86d308325839863f62d8caa89